### PR TITLE
Refactor prediction to be training method agnostic

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,6 @@
+# Each forecast prediction must output a BigQuery destination table with the following columns
+FORECAST_TIME_SERIES_IDENTIFIER_COLUMN = "time_series_identifier"
+FORECAST_TIME_COLUMN = "time_column"
+FORECAST_TARGET_COLUMN = "target_column"
+FORECAST_TARGET_COLUMN_LOWER_BOUND = "target_column_lower_bound"
+FORECAST_TARGET_COLUMN_UPPER_BOUND = "target_column_upper_bound"

--- a/main.py
+++ b/main.py
@@ -322,11 +322,28 @@ async def prediction(job_id: str, output_type: str):
                 for group, time_values_map in group_time_value_map.items()
             ]
 
+            historical_time_values = df_history[
+                job_request.model_parameters["timeColumn"]
+            ]
+            historyMinDate = (
+                historical_time_values.min().isoformat()
+                if len(historical_time_values) > 0
+                else None
+            )
             historyMaxDate = (
-                unique_times[-1].isoformat() if len(unique_times) > 0 else None
+                historical_time_values.max().isoformat()
+                if len(historical_time_values) > 0
+                else None
             )
 
-            return {"lines": lines, "historyMaxDate": historyMaxDate}
+            historicalBounds = None
+            if historyMinDate is not None and historyMaxDate is not None:
+                historicalBounds = {"min": historyMinDate, "max": historyMaxDate}
+
+            return {
+                "lines": lines,
+                "historicalBounds": historicalBounds,
+            }
         else:
             raise HTTPException(
                 status_code=400,

--- a/services/dataset_service.py
+++ b/services/dataset_service.py
@@ -5,7 +5,7 @@ from models import dataset
 
 DATASETS = [
     dataset.CSVDataset(
-        "sample_data/sales_forecasting_train_simple.csv",
+        "sample_data/sales_forecasting_train.csv",
         display_name="Retail Sales",
         time_column="date",
         description="This is sales data from a fictional sporting goods company with several stores across the city. It includes sales data for several products, grouped in several categories.",

--- a/services/forecast_job_service.py
+++ b/services/forecast_job_service.py
@@ -71,7 +71,9 @@ class ForecastJobService:
 
             # Run prediction
             output.prediction_uri = training_method.predict(
-                model=output.model_uri, parameters=request.prediction_parameters
+                model=output.model_uri,
+                model_parameters=request.model_parameters,
+                prediction_parameters=request.prediction_parameters,
             )
         except Exception as exception:
             output.error_message = str(exception)

--- a/training_methods/debug_training_method.py
+++ b/training_methods/debug_training_method.py
@@ -79,12 +79,18 @@ class DebugTrainingMethod(training_method.TrainingMethod):
 
         return "debug.evaluation"
 
-    def predict(self, model: str, parameters: Dict[str, Any]) -> str:
+    def predict(
+        self,
+        model: str,
+        model_parameters: Dict[str, Any],
+        prediction_parameters: Dict[str, Any],
+    ) -> str:
         """Predict using a model and return the BigQuery URI to its prediction table.
 
         Args:
             model (str): Model to evaluate.
-            parameters (Dict[str, Any]): The prediction parameters.
+            model_parameters (Dict[str, Any]): The model training parameters.
+            prediction_parameters (Dict[str, Any]): The prediction parameters.
 
         Returns:
             str: The BigQuery prediction table URI.

--- a/training_methods/training_method.py
+++ b/training_methods/training_method.py
@@ -57,12 +57,18 @@ class TrainingMethod(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def predict(self, model: str, parameters: Dict[str, Any]) -> str:
+    def predict(
+        self,
+        model: str,
+        model_parameters: Dict[str, Any],
+        prediction_parameters: Dict[str, Any],
+    ) -> str:
         """Predict using a model and return the BigQuery URI to its prediction table.
 
         Args:
             model (str): Model to evaluate.
-            parameters (Dict[str, Any]): The prediction parameters.
+            model_parameters (Dict[str, Any]): The model training parameters.
+            prediction_parameters (Dict[str, Any]): The prediction parameters.
 
         Returns:
             str: The BigQuery prediction table URI.


### PR DESCRIPTION
Currently, the "/prediction/{job_id}/{output_type}" route has hardcoded values that only work for BQML.

This PR moves that logic into the BQML training method and establishes common column names (see constants.py) that each training method output should adhere to.

Additionally, the plotly output format is supported.